### PR TITLE
Sets a default message for invalid

### DIFF
--- a/lib/mask_validator.rb
+++ b/lib/mask_validator.rb
@@ -65,7 +65,7 @@ class MaskValidator < ActiveModel::EachValidator
   private
 
   def message
-    options[:message]
+    options[:message] || :invalid
   end
 
   def normalize_value(record, attribute, value)


### PR DESCRIPTION
The default behavior of error messages changed in AM 4.1, so it is now required to set the default message to invalid.

The change can be seen here: https://github.com/rails/rails/commit/ca99ab2481d44d67bc392d0ec1125ff1439e9f94)
